### PR TITLE
Add optional whole-service check to delay rotation

### DIFF
--- a/billow/billowBalancer.py
+++ b/billow/billowBalancer.py
@@ -270,3 +270,8 @@ class billowBalancer(object):
         self.__load()
         self.__load_attrs()
         return self.rawattrs.connection_draining.timeout
+
+    @property
+    def dns_name(self):
+        self.__load()
+        return self.rawelb.dns_name

--- a/billow/billowGroup.py
+++ b/billow/billowGroup.py
@@ -189,6 +189,8 @@ class billowGroup(object):
                 self.settings['urlstatus'] = settings['urlstatus']
             if 'urlsuccess' in settings:
                 self.settings['urlsuccess'] = settings['urlsuccess']
+            if 'urlservicestatus' in settings:
+                self.settings['urlservicestatus'] = settings['urlservicestatus']
 
     def __load_config(self):
         if not self.rawconfig:


### PR DESCRIPTION
- Uses 'urlservicestatus' to define balancer port:/path/to/status
- Polls until OK / {{urlsuccess}} code returns, same as for instance
  status

cc @darach
